### PR TITLE
`git.Pull` uses `git pull --ff-only`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         run: go build
       - name: test
         run: go list -f '{{.Dir}}' -m | xargs go test
+        env:
+          MAESTRO_CI: true
       - name: tidy maestro
         run: go mod tidy
       - name: tidy composable

--- a/README.md
+++ b/README.md
@@ -5,11 +5,30 @@
 
 A developer utility.
 
-## Getting started
+## APIs
+
+[maestro/git](git) provides APIs for syncing a multi-repository workspace. `git.NewWorkspace` scans a directory for git
+repositories and provides access to the `Workspace.Sync` operation. Syncing delegates to `git.Clone` and `git.Pull` for
+each `git.Repository` configured with the workspace whether it's present or absent on within the workspace dir.
+
+The [maestro/composable](composable) module has wrappers for `exec.Cmd` to be used for managing local development
+processes and performing process healthchecks with HTTP GET and shell commands.
+[Previous iterations](https://github.com/eighty4/maestro/tree/b0c01b535b79a2fc0b9d553a7b18dd4697f74beb) could configure
+Gradle tasks, npm scripts and shell commands from a `.maestro` file.
+Re-visiting the project with the opportunity to use new Go [tooling](https://go.dev/doc/tutorial/workspaces) and
+[language](https://go.dev/doc/tutorial/generics) features (workspaces and generics), I rewrote process management
+but have yet to reimplement configuring and managing a local development environment.
+
+## Installing
 
 Use Go 1.19 or later, and run `go install github.com/eighty4/maestro@latest`.
 
-## Workspaces
+## Syncing with `maestro git`
 
-Maestro will sync a workspace of git repositories with the `maestro git` command. That command will perform a `git pull`
-on any repositories found in the directory its run from.
+Maestro will sync a workspace of git repositories with the `maestro git` command. This command scans the current
+directory and all subdirectories for git repositories and performs a `git pull --ff-only` in each repository.
+
+A `maestro.yaml` file allows repositories to be configured, enabling a `maestro git` command to also clone repositories
+not already present in the workspace. Eventually this feature could be used to enable an export->import of a dev
+machine's workspaces before formatting or replacing hardware. Configuring a `maestro.yaml` example is
+[in the tests](config_test.go#L41).

--- a/git/git.go
+++ b/git/git.go
@@ -30,19 +30,19 @@ type CloneUpdate struct {
 type PullStatus string
 
 const (
-	Pulling              PullStatus = "Pulling"
-	Pulled               PullStatus = "Pulled"
-	CouldNotResolveHost  PullStatus = "CouldNotResolveHost"
-	ConnectionFailure    PullStatus = "ConnectionFailure"
-	MergeConflict        PullStatus = "MergeConflict"
-	DetachedHead         PullStatus = "DetachedHead"
-	DivergentBranches    PullStatus = "DivergentBranches"
-	PullRepoNotFound     PullStatus = "RepositoryNotFound"
-	RemoteBranchNotFound PullStatus = "RemoteBranchNotFound"
-	UnsetUpstream        PullStatus = "UnsetUpstream"
-	UnstagedChanges      PullStatus = "UnstagedChanges"
-	NotRepository        PullStatus = "NotRepository"
-	PullFailed           PullStatus = "PullFailed"
+	Pulling                PullStatus = "Pulling"
+	Pulled                 PullStatus = "Pulled"
+	CouldNotResolveHost    PullStatus = "CouldNotResolveHost"
+	ConnectionFailure      PullStatus = "ConnectionFailure"
+	OverwritesLocalChanges PullStatus = "OverwritesLocalChanges"
+	MergeConflict          PullStatus = "MergeConflict"
+	DetachedHead           PullStatus = "DetachedHead"
+	PullRepoNotFound       PullStatus = "RepositoryNotFound"
+	RemoteBranchNotFound   PullStatus = "RemoteBranchNotFound"
+	UnsetUpstream          PullStatus = "UnsetUpstream"
+	UnstagedChanges        PullStatus = "UnstagedChanges"
+	NotRepository          PullStatus = "NotRepository"
+	PullFailed             PullStatus = "PullFailed"
 )
 
 type PullUpdate struct {
@@ -62,6 +62,7 @@ func Clone(dir string, url string) <-chan *CloneUpdate {
 	go func() {
 		c <- &CloneUpdate{Status: Cloning}
 		gitCloneCmd := exec.Command("git", "clone", url, dir)
+		// GIT_TERMINAL_PROMPT=0 prevents stdin prompting for http auth credentials
 		gitCloneCmd.Env = []string{"GIT_TERMINAL_PROMPT=0"}
 		var stderr bytes.Buffer
 		gitCloneCmd.Stdout = nil
@@ -108,11 +109,10 @@ func makeCloneErrorUpdate(stderr string) *CloneUpdate {
 }
 
 func Pull(dir string) <-chan *PullUpdate {
-	// todo parameterize with Default, Merge, Rebase and FF-only behaviors
 	c := make(chan *PullUpdate)
 	go func() {
 		c <- &PullUpdate{Status: Pulling}
-		gitPullCmd := exec.Command("git", "pull")
+		gitPullCmd := exec.Command("git", "pull", "--ff-only")
 		gitPullCmd.Dir = dir
 		var stdout bytes.Buffer
 		gitPullCmd.Stdout = &stdout
@@ -133,10 +133,8 @@ func Pull(dir string) <-chan *PullUpdate {
 		} else {
 			update := makePullErrorUpdate(stderr.String())
 			if update == nil {
-				log.Printf("[ERROR] git.Pull(%s) unhandled error; stderr: %s", dir, stderr.String())
+				log.Printf("[ERROR] git.Pull(%s) unhandled error\nstderr:\n==========\n%s\n==========\n", dir, stderr.String())
 				update = &PullUpdate{Status: PullFailed, Message: err.Error()}
-			} else if update.Status == MergeConflict {
-				_ = RebaseAbort(dir)
 			}
 			c <- update
 		}
@@ -146,30 +144,38 @@ func Pull(dir string) <-chan *PullUpdate {
 }
 
 const (
-	pullConnectionFailureErr        = "fatal: Could not read from remote repository."
-	pullConnectionFailureMsg        = "connection failure with remote repository"
+	pullConnectionFailureErr = "fatal: Could not read from remote repository."
+	pullConnectionFailureMsg = "connection failure with remote repository"
+
 	pullGitHubRepositoryNotFoundErr = "ERROR: Repository not found"
-	pullDetachedHeadErr             = "You are not currently on a branch."
-	pullDetachedHeadMsg             = "detached from a branch"
-	pullDivergentBranchesErr        = "You have divergent branches and need to specify how to reconcile them."
-	pullDivergentBranchesMsg        = "divergent branches (require a merge or rebase)"
-	pullMergeConflictErr            = "Your local changes to the following files would be overwritten by merge:"
-	pullMergeConflictMsg            = "merge conflict"
-	pullRebaseConflictErr           = "Resolve all conflicts manually, mark them as resolved with"
-	pullRebaseConflictMsg           = "merge conflict (don't worry, rebase was aborted)"
-	pullRemoteBranchNotFoundErr     = "from the remote, but no such ref was fetched."
-	pullRemoteBranchNotFoundMsg     = "tracking branch not found on remote"
-	pullUnstagedChangesErr          = "You have unstaged changes."
-	pullUnstagedChangesMsg          = "unstaged changes"
-	pullUnsetUpstreamErr            = "There is no tracking information for the current branch."
-	pullUnsetUpstreamMsg            = "not tracking an upstream remote"
-	pullRepositoryNotFoundErrPre    = "fatal: repository"
-	pullRepositoryNotFoundErrPost   = "not found"
-	pullRepositoryNotFoundMsg       = "repository not found"
-	pullNotRepositoryErr            = "fatal: not a git repository (or any of the parent directories): .git"
-	pullNotRepositoryMsg            = "not a repository"
-	pullCouldNotResolveHostErr      = "Could not resolve host: "
-	pullCouldNotResolveHostMsg      = "could not resolve host"
+
+	pullDetachedHeadErr = "You are not currently on a branch."
+	pullDetachedHeadMsg = "detached from a branch"
+
+	pullOverwritesLocalChangesErr = "Your local changes to the following files would be overwritten by merge:"
+	pullOverwritesLocalChangesMsg = "local changes would be overwritten"
+
+	pullMergeConflictErr = "fatal: Not possible to fast-forward, aborting."
+	pullMergeConflictMsg = "unable to pull without a merge or interactive rebase"
+
+	pullRemoteBranchNotFoundErr = "from the remote, but no such ref was fetched."
+	pullRemoteBranchNotFoundMsg = "tracking branch not found on remote"
+
+	pullUnstagedChangesErr = "You have unstaged changes."
+	pullUnstagedChangesMsg = "unstaged changes"
+
+	pullUnsetUpstreamErr = "There is no tracking information for the current branch."
+	pullUnsetUpstreamMsg = "not tracking an upstream remote"
+
+	pullRepositoryNotFoundErrPre  = "fatal: repository"
+	pullRepositoryNotFoundErrPost = "not found"
+	pullRepositoryNotFoundMsg     = "repository not found"
+
+	pullNotRepositoryErr = "fatal: not a git repository (or any of the parent directories): .git"
+	pullNotRepositoryMsg = "not a repository"
+
+	pullCouldNotResolveHostErr = "Could not resolve host: "
+	pullCouldNotResolveHostMsg = "could not resolve host"
 )
 
 func makePullErrorUpdate(stderr string) *PullUpdate {
@@ -189,12 +195,10 @@ func makePullErrorUpdate(stderr string) *PullUpdate {
 				return &PullUpdate{Status: ConnectionFailure, Message: fmt.Sprintf(`"%s"`, message)}
 			}
 		}
+	} else if strings.Contains(stderr, pullOverwritesLocalChangesErr) {
+		return &PullUpdate{Status: OverwritesLocalChanges, Message: pullOverwritesLocalChangesMsg}
 	} else if strings.Contains(stderr, pullMergeConflictErr) {
 		return &PullUpdate{Status: MergeConflict, Message: pullMergeConflictMsg}
-	} else if strings.Contains(stderr, pullRebaseConflictErr) {
-		return &PullUpdate{Status: MergeConflict, Message: pullRebaseConflictMsg}
-	} else if strings.Contains(stderr, pullDivergentBranchesErr) {
-		return &PullUpdate{Status: DivergentBranches, Message: pullDivergentBranchesMsg}
 	} else if strings.Contains(stderr, pullDetachedHeadErr) {
 		return &PullUpdate{Status: DetachedHead, Message: pullDetachedHeadMsg}
 	} else if strings.Contains(stderr, pullRemoteBranchNotFoundErr) {
@@ -212,12 +216,6 @@ func makePullErrorUpdate(stderr string) *PullUpdate {
 	} else {
 		return nil
 	}
-}
-
-func RebaseAbort(dir string) error {
-	gitPullCmd := exec.Command("git", "rebase", "--abort")
-	gitPullCmd.Dir = dir
-	return gitPullCmd.Run()
 }
 
 // RevParseShowTopLevel returns absolute path of top level directory of Git repository.

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -19,9 +19,13 @@ func TestMain(m *testing.M) {
 }
 
 func gitIntegrationTest(t *testing.T) {
-	//if os.Getenv("MAESTRO_GIT_TESTING") != "true" {
-	//	t.Skip("set MAESTRO_GIT_TESTING=true to run integration tests")
-	//}
+	//t.Skip("skipping git integration tests")
+}
+
+func skipOnCi(t *testing.T) {
+	if os.Getenv("MAESTRO_CI") == "true" {
+		t.Skip("skipping on ci test run")
+	}
 }
 
 func testCloneChannel(t *testing.T, c <-chan *CloneUpdate, expStatus CloneStatus, expMessage string) {
@@ -133,6 +137,18 @@ func testPullChannel(t *testing.T, p <-chan *PullUpdate, expStatus PullStatus, e
 	assert.Nil(t, u)
 }
 
+func assertNotRebasing(t *testing.T, dir string) {
+	gitStatusCmd := exec.Command("git", "status")
+	gitStatusCmd.Dir = dir
+	var stdout bytes.Buffer
+	gitStatusCmd.Stdout = &stdout
+	if err := gitStatusCmd.Run(); err != nil {
+		t.Fatal(err)
+	} else {
+		assert.False(t, strings.Contains(stdout.String(), "You are currently rebasing branch"))
+	}
+}
+
 func TestPull(t *testing.T) {
 	gitIntegrationTest(t)
 	dir := testutil.MkTmpDir(t)
@@ -151,6 +167,20 @@ func TestPull_WithLocalCommits(t *testing.T) {
 	testutil.CommitNewFile(t, dir, "file1")
 
 	testPullChannel(t, Pull(dir), Pulled, "", &RepoState{LocalCommits: 1})
+}
+
+func TestPull_WithUnstagedChanges(t *testing.T) {
+	gitIntegrationTest(t)
+	dir := testutil.MkTmpDir(t)
+	defer testutil.RmDir(t, dir)
+	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
+	testutil.OpenFileForWriting(t, dir, "README.md", func(f *os.File) {
+		if _, err := f.WriteString("unstaged change"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	testPullChannel(t, Pull(dir), Pulled, "", &RepoState{LocalCommits: 0})
 }
 
 func TestPull_Fails_DirNotRepo(t *testing.T) {
@@ -188,84 +218,19 @@ func TestPull_Fails_WithDetachedHead(t *testing.T) {
 	testPullChannel(t, Pull(dir), DetachedHead, "detached from a branch", nil)
 }
 
-const pullDivergentBranches = `
-hint: You have divergent branches and need to specify how to reconcile them.
-hint: You can do so by running one of the following commands sometime before
-hint: your next pull:
-hint: 
-hint:   git config pull.rebase false  # merge
-hint:   git config pull.rebase true   # rebase
-hint:   git config pull.ff only       # fast-forward only
-hint: 
-hint: You can replace "git config" with "git config --global" to set a default
-hint: preference for all repositories. You can also pass --rebase, --no-rebase,
-hint: or --ff-only on the command line to override the configured default per
-hint: invocation.
-fatal: Need to specify how to reconcile divergent branches.`
-
-func TestMakePullErrorUpdate_ForDivergentBranches(t *testing.T) {
-	u := makePullErrorUpdate(pullDivergentBranches[1:])
-	assert.Equal(t, DivergentBranches, u.Status)
-	assert.Equal(t, "divergent branches (require a merge or rebase)", u.Message)
-	assert.Nil(t, u.RepoState)
-}
-
-func TestPull_Fails_WithDivergentBranches(t *testing.T) {
-	gitIntegrationTest(t)
-	dir := testutil.MkTmpDir(t)
-	defer testutil.RmDir(t, dir)
-	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
-	testutil.ResetHard(t, dir, 1)
-	testutil.CommitNewFile(t, dir, "file1")
-
-	testPullChannel(t, Pull(dir), DivergentBranches, "divergent branches (require a merge or rebase)", nil)
-}
-
-const pullMergeConflict = `
-error: Your local changes to the following files would be overwritten by merge:
-	README.md
-Please commit your changes or stash them before you merge.
-Aborting`
+const pullNotPossibleToFastForward = `
+fatal: Not possible to fast-forward, aborting.
+`
 
 func TestMakePullErrorUpdate_ForMergeConflict(t *testing.T) {
-	u := makePullErrorUpdate(pullMergeConflict[1:])
+	u := makePullErrorUpdate(pullNotPossibleToFastForward[1:])
 	assert.Equal(t, MergeConflict, u.Status)
-	assert.Equal(t, "merge conflict", u.Message)
+	assert.Equal(t, "unable to pull without a merge or interactive rebase", u.Message)
 	assert.Nil(t, u.RepoState)
 }
 
-func TestPull_Fails_WithMergeConflict_WhenMerging(t *testing.T) {
+func TestPull_Fails_WithMergeConflict(t *testing.T) {
 	gitIntegrationTest(t)
-	dir := testutil.MkTmpDir(t)
-	defer testutil.RmDir(t, dir)
-	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
-	testutil.ResetHard(t, dir, 1)
-	testutil.OpenFileForOverwriting(t, dir, "README.md", func(f *os.File) {
-		if _, err := f.WriteString("merge conflict"); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	testPullChannel(t, Pull(dir), MergeConflict, "merge conflict", nil)
-}
-
-const pullRebaseConflict = `
-error: could not apply f4d2207... "README.md"
-hint: Resolve all conflicts manually, mark them as resolved with
-hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
-hint: You can instead skip this commit: run "git rebase --skip".
-hint: To abort and get back to the state before "git rebase", run "git rebase --abort".`
-
-func TestMakePullErrorUpdate_ForRebaseConflict(t *testing.T) {
-	u := makePullErrorUpdate(pullRebaseConflict[1:])
-	assert.Equal(t, MergeConflict, u.Status)
-	assert.Equal(t, "merge conflict (don't worry, rebase was aborted)", u.Message)
-	assert.Nil(t, u.RepoState)
-}
-
-func TestPull_Fails_WithMergeConflict_WhenRebasing(t *testing.T) {
-	gitIntegrationTest(t)
-	t.Skip("this scenario requires parameterizing `git pull` with `--rebase`")
 	dir := testutil.MkTmpDir(t)
 	defer testutil.RmDir(t, dir)
 	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
@@ -277,17 +242,37 @@ func TestPull_Fails_WithMergeConflict_WhenRebasing(t *testing.T) {
 	})
 	testutil.AddAndCommit(t, dir, "README.md")
 
-	testPullChannel(t, Pull(dir), MergeConflict, "merge conflict (don't worry, rebase was aborted)", nil)
+	testPullChannel(t, Pull(dir), MergeConflict, "unable to pull without a merge or interactive rebase", nil)
+	assertNotRebasing(t, dir)
+}
 
-	gitStatusCmd := exec.Command("git", "status")
-	gitStatusCmd.Dir = dir
-	var stdout bytes.Buffer
-	gitStatusCmd.Stdout = &stdout
-	if err := gitStatusCmd.Run(); err != nil {
-		t.Fatal(err)
-	} else {
-		assert.False(t, strings.Contains(stdout.String(), "You are currently rebasing branch"))
-	}
+const pullMergeConflict = `
+error: Your local changes to the following files would be overwritten by merge:
+	README.md
+Please commit your changes or stash them before you merge.
+Aborting`
+
+func TestMakePullErrorUpdate_ForOverwritesLocalChanges(t *testing.T) {
+	u := makePullErrorUpdate(pullMergeConflict[1:])
+	assert.Equal(t, OverwritesLocalChanges, u.Status)
+	assert.Equal(t, "local changes would be overwritten", u.Message)
+	assert.Nil(t, u.RepoState)
+}
+
+func TestPull_Fails_WithOverwritesLocalChanges(t *testing.T) {
+	gitIntegrationTest(t)
+	dir := testutil.MkTmpDir(t)
+	defer testutil.RmDir(t, dir)
+	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
+	testutil.ResetHard(t, dir, 1)
+	testutil.OpenFileForOverwriting(t, dir, "README.md", func(f *os.File) {
+		if _, err := f.WriteString("merge conflict"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	testPullChannel(t, Pull(dir), OverwritesLocalChanges, "local changes would be overwritten", nil)
+	assertNotRebasing(t, dir)
 }
 
 const pullConnectionFailure = `
@@ -365,8 +350,9 @@ func TestMakePullErrorUpdate_ForGitHubNotFound(t *testing.T) {
 }
 
 func TestPull_Fails_WithGitHubRepoNotFoundConnectionError_MappedToRepositoryNotFound(t *testing.T) {
+	t.Skip("`git pull` fails with `unable to fork` when running all tests in git_test.go, passes individually")
+	skipOnCi(t)
 	gitIntegrationTest(t)
-	t.Skip("unable to run on CI because it requires SSH auth to GitHub")
 	dir := testutil.MkTmpDir(t)
 	defer testutil.RmDir(t, dir)
 	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
@@ -387,7 +373,7 @@ func TestMakePullErrorUpdate_ForCouldNotResolveHost(t *testing.T) {
 
 func TestPull_Fails_WithCouldNotResolveHost(t *testing.T) {
 	gitIntegrationTest(t)
-	t.Skip("must disconnect from WiFi/ethernet between clone and pull or use namespace to deny network")
+	t.Skip("not really testable")
 	dir := testutil.MkTmpDir(t)
 	defer testutil.RmDir(t, dir)
 	testutil.CloneRepo(t, dir, "https://gibhub.com/eighty4/sse")
@@ -449,32 +435,6 @@ func TestPull_Fails_WithUnsetUpstream(t *testing.T) {
 	testutil.InitRepo(t, dir)
 
 	testPullChannel(t, Pull(dir), UnsetUpstream, "not tracking an upstream remote", nil)
-}
-
-const pullUnstagedChanges = `
-error: cannot pull with rebase: You have unstaged changes.
-error: please commit or stash them.`
-
-func TestMakePullErrorUpdate_ForUnstagedChanges(t *testing.T) {
-	u := makePullErrorUpdate(pullUnstagedChanges[1:])
-	assert.Equal(t, UnstagedChanges, u.Status)
-	assert.Equal(t, "unstaged changes", u.Message)
-	assert.Nil(t, u.RepoState)
-}
-
-func TestPull_Fails_WithUnstagedChanges(t *testing.T) {
-	gitIntegrationTest(t)
-	t.Skip("this scenario requires parameterizing `git pull` with `--rebase`")
-	dir := testutil.MkTmpDir(t)
-	defer testutil.RmDir(t, dir)
-	testutil.CloneRepo(t, dir, "https://github.com/eighty4/sse")
-	testutil.OpenFileForWriting(t, dir, "README.md", func(f *os.File) {
-		if _, err := f.WriteString("unstaged change"); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	testPullChannel(t, Pull(dir), UnstagedChanges, "unstaged changes", nil)
 }
 
 const pullRepositoryNotFound = `

--- a/git/workspace.go
+++ b/git/workspace.go
@@ -118,11 +118,11 @@ func (w *Workspace) Sync() <-chan *SyncUpdate {
 						message := ""
 						status := SyncSuccess
 						if s.PulledCommits > 0 {
-							message = fmt.Sprintf("pulled %d commits", s.PulledCommits)
+							message = fmt.Sprintf("pulled %d %s", s.PulledCommits, util.PluralPrint("commit", s.PulledCommits))
 						}
 						if s.RepoState.LocalCommits > 0 {
 							status = SyncWarning
-							localCommitMessage := fmt.Sprintf("%d local commits", s.RepoState.LocalCommits)
+							localCommitMessage := fmt.Sprintf("%d local %s", s.RepoState.LocalCommits, util.PluralPrint("commit", s.RepoState.LocalCommits))
 							if message == "" {
 								message = localCommitMessage
 							} else {

--- a/maestro.go
+++ b/maestro.go
@@ -40,6 +40,8 @@ func gitSync(cfg *Config) {
 		repositories = cfg.Repositories
 	}
 	ws := git.NewWorkspace(util.Cwd(), repositories, 2)
+
+	// calc max len of a repo name for print formatting
 	maxNameLen := 0
 	for _, repo := range ws.Repositories {
 		nameLen := len(repo.Name)
@@ -49,6 +51,7 @@ func gitSync(cfg *Config) {
 	}
 
 	up := NewUnicodePrinting()
+	// escapes %% to % so given maxNameLen == 3, fmtStr := "  %3s %s\n"
 	fmtStr := fmt.Sprintf("  %%%ds %%s %%s\n", maxNameLen)
 
 	printStatusUpdate := func(s *git.SyncUpdate) {
@@ -67,14 +70,14 @@ func gitSync(cfg *Config) {
 		fmt.Printf(fmtStr, s.Repo, checkOrX, s.Message)
 	}
 
-	println(fmt.Sprintf("Updating %d repositories", len(ws.Repositories)))
+	println(fmt.Sprintf("Syncing %d repositories", len(ws.Repositories)))
 	c := ws.Sync()
 	for {
 		update, ok := <-c
 		if ok {
 			printStatusUpdate(update)
 		} else {
-			println("Finished!")
+			println("Done!")
 			break
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -30,3 +30,11 @@ func IsDir(path string) bool {
 func Seconds(n int8) time.Duration {
 	return Duration(time.Second, n)
 }
+
+func PluralPrint(s string, n int) string {
+	if n == 1 {
+		return s
+	} else {
+		return s + "s"
+	}
+}


### PR DESCRIPTION
Refactor appropriately for non-interactive mode

closes #11 